### PR TITLE
Fix Clip Downloading Bug

### DIFF
--- a/internal/twitch/twitch_manager.go
+++ b/internal/twitch/twitch_manager.go
@@ -122,27 +122,14 @@ func constructRawMP4URLFromClip(clip Clip) string {
 	log.Println("Making download url for clip with id: " + clip.ID)
 
 	token := clip.PlaybackAccessToken
-	value := getValueFromToken(clip.PlaybackAccessToken)
 
-	if (value.ClipURI == "") {
-		return ""
-	}
+	clipURI := clip.VideoQualities[0].SourceURL
 
 	params := url.Values{}
 	params.Set("response-content-disposition", "attachment")
 	params.Set("sig", token.Signature)
 	params.Set("token", token.Value)
-	finalURL := fmt.Sprintf("%s?%s", value.ClipURI, params.Encode())
+	finalURL := fmt.Sprintf("%s?%s", clipURI, params.Encode())
 	return finalURL
 }
 
-//TODO: This function should not be needed...
-// getValueFromToken unmarshals the value field into a Value struct
-func getValueFromToken(token PlaybackAccessToken) Value {
-	var value Value
-	err := json.Unmarshal([]byte(token.Value), &value)
-	if err != nil {
-		log.Fatalf("Error unmarshalling JSON: %v", err)
-	}
-	return value
-}


### PR DESCRIPTION
Problem: Fix issue where clips couldn't be downloaded due to a missing clip URI.
Source of Problem: 
- We were pulling the value "clip-uri" from PlaybackAccessToken which was empty for certain clips when constructing the clip's raw mp4 url
Fix:
- You can pull the equivalent value of PlaybackAccessToken.ClipURI by getting the first entry of videoQualities (which is the 1920x1080 60fps clip video quality) and getting the value for the sourceURL field.